### PR TITLE
Parse embargo periods for "restricted" policy 

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -44,7 +44,13 @@ parse_answer = function(api_answer, multiple = FALSE) {
     postprint = xml_text(xml_find_first(xml_source, "//postarchiving"))
     pdf = xml_text(xml_find_first(xml_source, "//pdfarchiving"))
 
-    return(data.frame(title, issn, preprint, postprint, pdf, romeocolour))
+    pre_embargo = parse_embargo(xml_source, "pre")
+    post_embargo = parse_embargo(xml_source, "post")
+    pdf_embargo = parse_embargo(xml_source, "pdf")
+
+    return(data.frame(title, issn, romeocolour,
+                      preprint, postprint, pdf,
+                      pre_embargo, post_embargo, pdf_embargo))
 
   } else {
 
@@ -124,3 +130,20 @@ check_key = function(key) {
 
   return(tmp)
 }
+
+parse_embargo = function(xml_source, type) {
+
+  tag = paste0("//", type, "restriction")
+  embargo_field = xml_text(xml_find_first(xml_source, tag))
+
+  if (is.na(embargo_field)) {
+    return(NA_character_)
+  }
+  else {
+    embargo_field = read_html(embargo_field)
+    time = xml_text(xml_find_first(embargo_field, "//num"))
+    unit = xml_text(xml_find_first(embargo_field, "//period"))
+    return(paste(time, unit))
+  }
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -131,6 +131,15 @@ check_key = function(key) {
   return(tmp)
 }
 
+#' Parse embargo period from API return
+#'
+#' This function provides an easy way to return the embargo period in the
+#' different categories
+#' @param xml_source a parsed xml document
+#' @param type       name of the embargo type must be in `"pre"`, `"post"`, and
+#'                   `"pdf"`
+#'
+#' @return the embargo period as a string
 parse_embargo = function(xml_source, type) {
 
   tag = paste0("//", type, "restriction")


### PR DESCRIPTION
It would be good at some point to parse dates in a more clever way. Right now, some of them will be in months and other in years.

I know there are packages to do this. We will have to decide if that's worth an additional dependency.

Anyways, this should work well enough for now.